### PR TITLE
Fix binary permissions

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,13 @@ class sera (
 		extract_path => "/usr/local/bin",
 		creates      => "/usr/local/bin/sera",
 	}
+	
+	file { "/usr/local/bin/sera": 
+		owner => "root",
+		group => "root",
+		mode => 0755;
+	}
+	
 	file { "/etc/sera.json":
 		content => template("sera/sera.json.erb"),
 		owner => "root",


### PR DESCRIPTION
Ensure that the binary has the right owner and permissions.

Now it will use the permissions and user on the system where the binary was compiled and archived