### PR TITLE
Convert legacy validate functions to parameter types

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,15 +1,9 @@
 class sera (
-	$version,
-	$dbuser,
-	$dbpassword,
-	$dbserver,
+	String $version,
+	String $dbuser,
+	String $dbpassword,
+	String $dbserver,
 ) {
-
-	validate_string($version)
-	validate_string($dbuser)
-	validate_string($dbpassword)
-	validate_string($dbserver)
-
 	archive { "/tmp/sera_${version}_linux_amd64.tar.gz":
 		provider     => 'curl',
 		source       => "https://github.com/silverstripeltd/sera/releases/download/${version}/sera_${version}_linux_amd64.tar.gz",
@@ -31,5 +25,4 @@ class sera (
 		group => "root",
 		mode => "0644",
 	}
-
 }


### PR DESCRIPTION
This is currently be used by `aws-projects` so should be included in a tagged release.